### PR TITLE
docs: fix the version to be downloaded from github for installation

### DIFF
--- a/src/pages/docs/daemon.md
+++ b/src/pages/docs/daemon.md
@@ -31,7 +31,7 @@ The following commands will download the Skyport Daemon into /etc/skyportd and u
 
 ``` bash
 cd /etc
-git clone --branch 0.2.0 https://github.com/skyportlabs/skyportd
+git clone --branch v0.2.0 https://github.com/skyportlabs/skyportd
 cd skyportd
 npm install
 ```

--- a/src/pages/docs/installation.md
+++ b/src/pages/docs/installation.md
@@ -44,7 +44,7 @@ The following commands will download the Skyport Panel into /etc/skyport and use
 
 ``` bash
 cd /etc
-git clone --branch 0.2.0 https://github.com/skyportlabs/panel
+git clone --branch v0.2.0 https://github.com/skyportlabs/panel
 mv panel skyport
 cd skyport
 npm install


### PR DESCRIPTION
I fixed the documentation because when installing I just copied the command and it said that the branch did not exist, so I created this PR to fix it for people who don't understand much about github but want to install the panel without any problems.